### PR TITLE
Correct the way etl_timestamp is stored

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap_bigquery",
-    version="0.1.4",
+    version="0.1.5",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap_bigquery",
-    version="0.1.5",
+    version="0.2.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_bigquery/sync_bigquery.py
+++ b/tap_bigquery/sync_bigquery.py
@@ -134,7 +134,7 @@ def do_sync(config, stream):
         for key in properties.keys():
             prop = properties[key]
             if "_etl_tstamp" in properties.keys() and key == "_etl_tstamp":
-                record["_etl_tstamp"] = time.time()
+                record["_etl_tstamp"] = int(round(time.time() * 1000))
             elif prop.format == "date-time":
                 record[key] = row[key].strftime("%Y-%m-%d %H:%M:%S")
             else:


### PR DESCRIPTION
Switch from float seconds to microseconds, that will make it easy to save in target with correct type timestamp